### PR TITLE
add warnings when creating/updating duplicate triggers (fixes #217)

### DIFF
--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/AddTriggerActivity.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/AddTriggerActivity.java
@@ -1,5 +1,6 @@
 package org.ovirt.mobile.movirt.ui.triggers;
 
+import org.androidannotations.annotations.Background;
 import org.androidannotations.annotations.EActivity;
 import org.ovirt.mobile.movirt.R;
 import org.ovirt.mobile.movirt.model.condition.Condition;
@@ -22,7 +23,15 @@ public class AddTriggerActivity extends BaseTriggerActivity {
         trigger.setCondition(condition);
         trigger.setNotificationType(getNotificationType());
 
-        provider.insert(trigger);
+        addTrigger(trigger);
         finish();
+    }
+
+    @Background
+    public void addTrigger(Trigger trigger) {
+        if (findSimilarTrigger(trigger) != null) {
+            commonMessageHelper.showToast(resources.getCreatedDuplicateTriggerError());
+        }
+        provider.insert(trigger);
     }
 }

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/BaseTriggerActivity.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/BaseTriggerActivity.java
@@ -28,6 +28,8 @@ import org.ovirt.mobile.movirt.model.mapping.EntityType;
 import org.ovirt.mobile.movirt.model.trigger.Trigger;
 import org.ovirt.mobile.movirt.provider.ProviderFacade;
 import org.ovirt.mobile.movirt.ui.BroadcastAwareAppCompatActivity;
+import org.ovirt.mobile.movirt.util.JsonUtils;
+import org.ovirt.mobile.movirt.util.message.CommonMessageHelper;
 import org.ovirt.mobile.movirt.util.resources.Resources;
 
 import java.util.regex.Pattern;
@@ -79,6 +81,9 @@ public abstract class BaseTriggerActivity extends BroadcastAwareAppCompatActivit
 
     @Bean
     Resources resources;
+
+    @Bean
+    CommonMessageHelper commonMessageHelper;
 
     @ViewById
     TextView statusText;
@@ -173,6 +178,21 @@ public abstract class BaseTriggerActivity extends BroadcastAwareAppCompatActivit
             default:
                 throw new RuntimeException("Unknown condition type selected");
         }
+    }
+
+    public Trigger findSimilarTrigger(Trigger trigger) {
+        final ProviderFacade.QueryBuilder<Trigger> builder = provider.query(Trigger.class)
+                .where(Trigger.ACCOUNT_ID, trigger.getAccountId())
+                .where(Trigger.CLUSTER_ID, trigger.getClusterId())
+                .where(Trigger.TARGET_ID, trigger.getTargetId())
+                .where(Trigger.NOTIFICATION, trigger.getNotificationType().toString())
+                .where(Trigger.CONDITION, JsonUtils.objectToString(trigger.getCondition()))
+                .where(Trigger.ENTITY_TYPE, trigger.getEntityType().toString());
+
+        if (trigger.getId() != null) {
+            builder.whereNotEqual(Trigger.ID, trigger.getId().toString());
+        }
+        return builder.first();
     }
 
     public EntityType getEntityType(Condition triggerCondition) {

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/EditTriggerActivity.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/EditTriggerActivity.java
@@ -9,6 +9,7 @@ import android.util.Log;
 import android.widget.ArrayAdapter;
 
 import org.androidannotations.annotations.AfterViews;
+import org.androidannotations.annotations.Background;
 import org.androidannotations.annotations.EActivity;
 import org.androidannotations.annotations.InstanceState;
 import org.ovirt.mobile.movirt.R;
@@ -139,8 +140,16 @@ public class EditTriggerActivity extends BaseTriggerActivity implements HasLoade
         trigger.setCondition(condition);
         trigger.setNotificationType(getNotificationType());
 
-        provider.update(trigger);
+        updateTrigger(trigger);
         finish();
+    }
+
+    @Background
+    public void updateTrigger(Trigger trigger) {
+        if (findSimilarTrigger(trigger) != null) {
+            commonMessageHelper.showToast(resources.getUpdateDuplicateTriggerError());
+        }
+        provider.update(trigger);
     }
 
     @Override

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/EditTriggerActivity.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/ui/triggers/EditTriggerActivity.java
@@ -139,6 +139,7 @@ public class EditTriggerActivity extends BaseTriggerActivity implements HasLoade
 
         trigger.setCondition(condition);
         trigger.setNotificationType(getNotificationType());
+        trigger.setEntityType(getEntityType(condition));
 
         updateTrigger(trigger);
         finish();

--- a/moVirt/src/main/java/org/ovirt/mobile/movirt/util/resources/Resources.java
+++ b/moVirt/src/main/java/org/ovirt/mobile/movirt/util/resources/Resources.java
@@ -21,4 +21,12 @@ public class Resources extends StringResources {
     public String getNoConsoleClientError() {
         return getString(R.string.no_console_client_error);
     }
+
+    public String getCreatedDuplicateTriggerError() {
+        return getString(R.string.create_duplicate_trigger_error);
+    }
+
+    public String getUpdateDuplicateTriggerError() {
+        return getString(R.string.update_duplicate_trigger_error);
+    }
 }

--- a/moVirt/src/main/res/values/strings.xml
+++ b/moVirt/src/main/res/values/strings.xml
@@ -308,6 +308,8 @@
     <string name="missing_accounts_permission_error">Missing GET ACCOUNTS permission. Application may be buggy.</string>
     <string name="no_console_file_error">Could not fetch console .vv file: %1$s</string>
     <string name="no_console_client_error">Failed to open console client. Check if aSPICE/bVNC is installed.</string>
+    <string name="create_duplicate_trigger_error">Created duplicate trigger.The same trigger already exists!"</string>
+    <string name="update_duplicate_trigger_error">Duplicate trigger. The same trigger already exists!"</string>
     <string name="badly_formatted_certs_error">Certificates badly formatted</string>
     <string name="not_self_signed_engine_error">Engine doesn\'t use self-signed CA, please report this issue.</string>
     <string name="cert_management_ovirt_default_url">oVirt\'s default URL</string>


### PR DESCRIPTION
resolved with warning, should we forbid that completely?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ovirt/movirt/279)
<!-- Reviewable:end -->
